### PR TITLE
replace Sentry Prevent with Codecov

### DIFF
--- a/.github/actions/codecov/action.yml
+++ b/.github/actions/codecov/action.yml
@@ -2,6 +2,11 @@
 name: Codecov
 description: Uploads test artifacts to Codecov
 
+inputs:
+  token:
+    description: Codecov token
+    required: true
+
 runs:
   using: composite
   steps:
@@ -14,4 +19,4 @@ runs:
       if: ${{ !cancelled() }}
       uses: codecov/codecov-action@v5
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ inputs.token }}

--- a/.github/actions/codecov/action.yml
+++ b/.github/actions/codecov/action.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/github-action.jsonc
-name: Sentry Prevent
-description: Runs Sentry Prevent to block commits that introduce new Sentry issues
+name: Codecov
+description: Uploads test artifacts to Codecov
 
 runs:
   using: composite
@@ -12,4 +12,6 @@ runs:
         path: packages
     - name: Upload
       if: ${{ !cancelled() }}
-      uses: getsentry/prevent-action@v0
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -97,7 +97,23 @@ jobs:
       - name: Audit
         uses: ./.github/actions/webhint-ci
 
-  # Stage 3: github-pages, npm-publish, sentry-prevent
+  # Stage 3: codecov, github-pages, npm-publish
+  codecov:
+    name: Codecov
+    environment: continuous-deployment
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Act
+        uses: ./.github/actions/codecov
+
   github-pages:
     name: GitHub Pages
     environment: production
@@ -144,22 +160,6 @@ jobs:
         uses: ./.github/actions/setup
       - name: Publish
         run: npm run publish
-
-  sentry-prevent:
-    name: Sentry Prevent
-    environment: continuous-deployment
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Scan
-        uses: ./.github/actions/sentry-prevent
 
   # Stage 4: cloudflare-purge, github-packages, wrangler-deploy
   cloudflare-purge:

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -105,7 +105,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -111,8 +111,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Act
+      - name: Upload
         uses: ./.github/actions/codecov
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   github-pages:
     name: GitHub Pages

--- a/.github/workflows/continuous-integration-failure.yml
+++ b/.github/workflows/continuous-integration-failure.yml
@@ -19,8 +19,7 @@ jobs:
     permissions:
       actions: read
       issues: write
-      # Add this permission if Copilot inherits this job's GITHUB_TOKEN.
-      # pull-requests: write
+      pull-requests: write
     steps:
       - name: Comment
         uses: actions/github-script@v7

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -89,9 +89,9 @@ jobs:
       - name: Audit
         uses: ./.github/actions/webhint-ci
 
-  # Stage 3: sentry-prevent
-  sentry-prevent:
-    name: Sentry Prevent
+  # Stage 3: codecov
+  codecov:
+    name: Codecov
     if: github.event.pull_request.head.repo.full_name == github.repository
     environment: continuous-integration
     needs: test
@@ -104,8 +104,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Scan
-        uses: ./.github/actions/sentry-prevent
+      - name: Act
+        uses: ./.github/actions/codecov
 
 on:
   pull_request:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -104,8 +104,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Act
+      - name: Upload
         uses: ./.github/actions/codecov
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
 on:
   pull_request:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -98,7 +98,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
# Summary

Replaces Sentry Prevent with Codecov, per the Sentry Prevent deprecation documentation.

<details>
@claude review
/gemini review
@sentry review
</details>
